### PR TITLE
Levels from existing hierarchical data

### DIFF
--- a/R/fabricate_data.R
+++ b/R/fabricate_data.R
@@ -98,11 +98,11 @@ fabricate_data_single_level_ <- function(
 
     # this creates column names from ID_label
     # note if ID_label is NULL that the ID column name is just "ID" -- so safe
-    colnames(data) <- paste(c(ID_label, "ID"), collapse = "_")
+    colnames(data) <- ID_label
   } else {
     N <- nrow(data)
     if (!is.null(ID_label) & existing_ID == FALSE) {
-      data[, paste(c(ID_label, "ID"), collapse = "_")] <-
+      data[, ID_label] <-
         sprintf(paste0("%0", nchar(nrow(data)), "d"), 1:nrow(data))
     }
   }

--- a/R/fabricate_data.R
+++ b/R/fabricate_data.R
@@ -39,28 +39,27 @@ fabricate_data <- function(..., N = NULL, ID_label = NULL, data = NULL) {
 
   # check if all the options are level calls
   if (all(sapply(options_text, function(x)
-    startsWith(x, "level("))) & length(options_text) > 0) {
+    startsWith(x, "level("))) &
+    length(options_text) > 0) {
 
     if (!is.null(data)) {
-      stop("If you are using levels, please don't include data as an argument;
-           instead, use level_data within the levels argument, i.e. level(level_data = your_data).")
+
+      ##stop("If you are using levels, please don't include data as an argument; instead, use level_data within the levels argument, i.e. level(level_data = your_data).")
+      ## instead, just let it start with the existing data
     }
 
-    # If we don't have data yet, make the first level.
-    if (is.null(data)) {
-      # Do a sweet switcheroo with the level names if applicable.
-      if (is.null(options[[1]]$expr$ID_label)) {
-        options[[1]]$expr$ID_label <- names(options)[1]
-      }
-      data <- lazy_eval(options[[1]])
-    }
+    ## make this work! needs to do a loop through all the options
 
     # iff there are multiple levels, please to continue
-    if (length(options) > 1) {
+    if ((length(options) + !is.null(data)) > 1) {
 
-      for (i in 2:length(options)) {
+      for (i in seq_along(options)) {
         # Pop the data from the previous level in the current call
-        options[[i]]$expr$data <- data
+        # Do this if there existing data to start with or
+        #   and beginning with the second level
+        if (i > 1 | !is.null(data)) {
+          options[[i]]$expr$data <- data
+        }
 
         # Also do a sweet switcheroo with the level names if applicable.
         if (is.null(options[[i]]$expr$ID_label)) {
@@ -82,7 +81,8 @@ fabricate_data <- function(..., N = NULL, ID_label = NULL, data = NULL) {
 
 
 #' @importFrom lazyeval f_eval as_f_list
-fabricate_data_single_level_ <- function(data = NULL, N = NULL, ID_label = NULL, args) {
+fabricate_data_single_level_ <- function(
+  data = NULL, N = NULL, ID_label = NULL, args, existing_ID = FALSE) {
   if (sum(!is.null(data),!is.null(N)) != 1) {
     stop("Please supply either a data.frame or N and not both.")
   }
@@ -101,7 +101,7 @@ fabricate_data_single_level_ <- function(data = NULL, N = NULL, ID_label = NULL,
     colnames(data) <- paste(c(ID_label, "ID"), collapse = "_")
   } else {
     N <- nrow(data)
-    if (!is.null(ID_label)) {
+    if (!is.null(ID_label) & existing_ID == FALSE) {
       data[, paste(c(ID_label, "ID"), collapse = "_")] <-
         sprintf(paste0("%0", nchar(nrow(data)), "d"), 1:nrow(data))
     }

--- a/R/level.R
+++ b/R/level.R
@@ -52,7 +52,7 @@ level <- function(ID_label, N = NULL, ..., level_data = NULL, by = NULL, data = 
     }
     # make IDs that are nicely padded
     data <- data.frame(sprintf(paste0("%0", nchar(N), "d"), 1:N), stringsAsFactors = FALSE)
-    colnames(data) <- paste(c(ID_label, "ID"), collapse = "_")
+    colnames(data) <- ID_label
 
   } else {
 

--- a/R/level.R
+++ b/R/level.R
@@ -61,7 +61,7 @@ level <- function(ID_label, N = NULL, ..., level_data = NULL, by = NULL, data = 
       # either provide an existing ID_label or N if you don't provide custom data
 
       # if there is no ID variable, expand the dataset based on the commands in N
-      if (!ID_label %in% names(data)) {
+      if (!ID_label %in% colnames(data)) {
 
         # this check copied and pasted from purrr
         N <- eval(substitute(N), envir = data)

--- a/tests/testthat/test-bootstrap.R
+++ b/tests/testthat/test-bootstrap.R
@@ -1,21 +1,24 @@
 context("Bootstrap")
 
-test_that("Bootstrap",{
+test_that("Bootstrap", {
+  two_levels <- fabricate_data(
+    regions = level(N = 5, gdp = rnorm(N)),
+    cities = level(N = sample(1:5), subways = rnorm(N, mean = gdp))
+  )
 
-two_levels <- fabricate_data(regions = level(N = 5, gdp = rnorm(N)),
-               cities = level(N = sample(1:5), subways = rnorm(N, mean = gdp)))
+  head(two_levels)
 
-head(two_levels)
+  q <- resample_data(two_levels, c(100, 10), ID_labels = c("regions", "cities"))
 
-q <- resample_data(two_levels, c(100, 10), ID_labels = c("regions_ID", "cities_ID"))
-
-q <- resample_data(two_levels, 5)
+  q <- resample_data(two_levels, 5)
 })
 
-test_that("Error handling of Bootstrap",{
-  two_levels <- fabricate_data(regions = level(N = 5, gdp = rnorm(N)),
-                               cities = level(N = sample(1:5), subways = rnorm(N, mean = gdp)))
+test_that("Error handling of Bootstrap", {
+  two_levels <- fabricate_data(
+    regions = level(N = 5, gdp = rnorm(N)),
+    cities = level(N = sample(1:5), subways = rnorm(N, mean = gdp))
+  )
 
   q <- resample_data(two_levels) # Missing N
-  expect_error(resample_data(two_levels, c(100, 10), ID_labels=c("Invalid_ID")))
+  expect_error(resample_data(two_levels, c(100, 10), ID_labels = c("Invalid_ID")))
 })

--- a/tests/testthat/test-start-with-existing-data.R
+++ b/tests/testthat/test-start-with-existing-data.R
@@ -8,23 +8,23 @@ test_that("Start with existing multi-level data and add variables",{
 
   ## add a variable at the region level
   fabricate_data(data = user_data,
-                 regions_ID = level(rob = paste0(regions_ID, "r") )) %>% head
+                 regions = level(rob = paste0(regions, "r") )) %>% head
 
   ## add a variable at the cities level
   fabricate_data(data = user_data,
-                 cities_ID = level(rob = paste0(cities_ID, "c"))) %>% head
+                 cities = level(rob = paste0(cities, "c"))) %>% head
 
   ## do both
   ## note this will break if you try to use cities_ID at the region level (intentional)!
   fabricate_data(data = user_data,
-                 regions_ID = level(rob = paste0(regions_ID, "r")),
-                 cities_ID = level(bob = paste0(cities_ID, "c"))) %>% head
-  
+                 regions = level(rob = paste0(regions, "r")),
+                 cities = level(bob = paste0(cities, "c"))) %>% head
+
   ## do both and create a new level at the bottom level
   ## note this will break if you try to use cities_ID at the region level (intentional)!
   fabricate_data(data = user_data,
-                 regions_ID = level(rob = paste0(regions_ID, "r")),
-                 cities_ID = level(bob = paste0(cities_ID, "c")),
+                 regions = level(rob = paste0(regions, "r")),
+                 cities = level(bob = paste0(cities, "c")),
                  neighborhoods = level(N = 10, tmp = rnorm(N))) %>% head
 
 })

--- a/tests/testthat/test-start-with-existing-data.R
+++ b/tests/testthat/test-start-with-existing-data.R
@@ -1,0 +1,23 @@
+context("Start with existing multi-level data and add variables")
+
+test_that("Start with existing multi-level data and add variables",{
+
+  user_data <- fabricate_data(
+    regions = level(N = 5, gdp = rnorm(N)),
+    cities = level(N = sample(1:5), subways = rnorm(N, mean = gdp)))
+
+  ## add a variable at the region level
+  fabricate_data(data = user_data,
+                 regions_ID = level(rob = paste0(regions_ID, "r") )) %>% head
+
+  ## add a variable at the cities level
+  fabricate_data(data = user_data,
+                 cities_ID = level(rob = paste0(cities_ID, "c"))) %>% head
+
+  ## do both
+  ## note this will break if you try to use cities_ID at the region level (intentional)!
+  fabricate_data(data = user_data,
+                 regions_ID = level(rob = paste0(regions_ID, "r")),
+                 cities_ID = level(bob = paste0(cities_ID, "c"))) %>% head
+
+})

--- a/tests/testthat/test-start-with-existing-data.R
+++ b/tests/testthat/test-start-with-existing-data.R
@@ -19,5 +19,12 @@ test_that("Start with existing multi-level data and add variables",{
   fabricate_data(data = user_data,
                  regions_ID = level(rob = paste0(regions_ID, "r")),
                  cities_ID = level(bob = paste0(cities_ID, "c"))) %>% head
+  
+  ## do both and create a new level at the bottom level
+  ## note this will break if you try to use cities_ID at the region level (intentional)!
+  fabricate_data(data = user_data,
+                 regions_ID = level(rob = paste0(regions_ID, "r")),
+                 cities_ID = level(bob = paste0(cities_ID, "c")),
+                 neighborhoods = level(N = 10, tmp = rnorm(N))) %>% head
 
 })


### PR DESCRIPTION
This pull request adds the ability to use level() to create new variables at *existing* levels of the data. So you can bring in a hierarchical dataset and add variables at any level in it, or you can start by making a level and later add variables (for example if they are summaries of lower level variables). Also removes the addition of "_ID" to the level ID variables. Various other bug fixes.