### PR TITLE
fix ordered

### DIFF
--- a/man/correlate.Rd
+++ b/man/correlate.Rd
@@ -18,12 +18,17 @@ Y will be correlated with.}
 \item{rho}{A rank correlation coefficient between -1 and 1.}
 }
 \description{
+This function is EXPERIMENTAL, and we cannot guarantee its properties for
+all data structures. Be sure to diagnose your design and assess the
+distribution of your variables.
+}
+\details{
 In order to generate a random variable of a specific distribution based on
 another variable of any distribution and a correlation coefficient `rho`,
 we map the first, known variable into the standard normal space via affine
 transformation, generate the conditional distribution of the resulting
 variable as a standard normal, and then map that standard normal back to
-the target distribution. The result ensures, in expectation, a rank-order
+the target distribution. The result should ensure, in expectation, a rank-order
 correlation of `rho`.
 }
 \examples{

--- a/man/draw_discrete.Rd
+++ b/man/draw_discrete.Rd
@@ -20,7 +20,7 @@ draw_categorical(prob = link(latent), N = NULL, latent = NULL,
 
 draw_ordered(x = link(latent), breaks = c(-1, 0, 1),
   break_labels = NULL, N = length(x), latent = NULL,
-  link = "identity", quantile_y = NULL)
+  strict = FALSE, link = "identity")
 
 draw_count(mean = link(latent), N = length(mean), latent = NULL,
   link = "identity", quantile_y = NULL)
@@ -29,7 +29,7 @@ draw_binary(prob = link(latent), N = length(prob), link = "identity",
   latent = NULL, quantile_y = NULL)
 
 draw_likert(x, type = 7, breaks = NULL, N = length(x),
-  latent = NULL, link = "identity", quantile_y = NULL)
+  latent = NULL, link = "identity", strict = !is.null(breaks))
 
 draw_quantile(type, N)
 }
@@ -67,6 +67,8 @@ categories with `draw_ordered` or `draw_likert`}
 
 \item{break_labels}{vector of labels for the breaks to cut a latent outcome
 into ordered categories with `draw_ordered`. (Optional)}
+
+\item{strict}{Logical indicating whether values outside the provided breaks should be coded as NA. Defaults to \code{FALSE}, in which case effectively additional breaks are added between -Inf and the lowest break and between the highest break and Inf.}
 
 \item{mean}{for `draw_count`, the mean number of count units for each observation}
 

--- a/tests/testthat/test-variables.R
+++ b/tests/testthat/test-variables.R
@@ -261,6 +261,42 @@ test_that("Ordered data valid tests", {
   )
   expect_equal(length(base_ordered), 200)
   expect_equal(length(table(base_ordered)), 4)
+})
+
+
+test_that("MH's tests",{
+  expect_equal(
+    draw_ordered(c(-1, .5, .5, .5, 5), breaks = c(1/3, 2/3)),
+    c(1, 2, 2, 2, 3))
+
+  expect_equal(
+    draw_ordered(c(.3, .5, .5), breaks = c(1/3, 2/3), strict = TRUE),
+    c(NA, 1, 1))
+
+  expect_equal(
+    draw_ordered(c(.3, .5, .5), breaks = c(1/3, 2/3)),
+    c(1, 2, 2))
+
+  expect_equal(
+    draw_ordered(c(.5, .5, .7), breaks = c(1/3, 2/3)),
+    c(2, 2, 3)
+  )
+
+  expect_equal(
+    draw_ordered(c(.5, .5, .7), breaks = c(1/3, 2/3), strict = TRUE),
+    c(1, 1, NA)
+  )
+
+  # now try with manual Inf's
+  expect_equal(
+    draw_ordered(c(.5, .5, 2/3, 1), breaks = c(-Inf, 2/3), strict = TRUE),
+    c(1, 1, 2, NA)
+  )
+
+  expect_equal(
+    draw_ordered(c(.5, .5, 2/3, 1), breaks = c(-Inf, 2/3)),
+    c(1, 1, 2, 2)
+  )
 
 })
 


### PR DESCRIPTION
closes https://github.com/DeclareDesign/fabricatr/issues/134

several changes to the draw_ordered and related functions

strict = TRUE means we replace any values outside the intervals you provide with NA's (i.e. if you do c(0, 1) any value outside 0, 1 will be NA). allows -Inf and Inf if you want to specify one or both of them.
strict = FALSE we do not do this, which effectively adds a -Inf lower bound and Inf upper bound