### PR TITLE
Changes to generating factors

### DIFF
--- a/NEWS.md
+++ b/NEWS.md
@@ -1,3 +1,9 @@
+# **fabricatr** (development version)
+
+- `draw_categorical()` now returns a factor when `category_labels` is specified.
+- `draw_ordered()` now returns an ordered factor when `break_labels` is specified.
+- `draw_ordered()` performance is improved when returning a factor.
+
 # **fabricatr** 0.16.0
 
 - Replacement `draw_likert` function.

--- a/R/variable_creation_functions.R
+++ b/R/variable_creation_functions.R
@@ -42,8 +42,8 @@
 #' stochastically from the distribution of interest, data will be drawn at
 #' exactly those quantiles.
 #' @return A vector of data in accordance with the specification; generally
-#' numeric but for some functions, including \code{draw_ordered}, may be factor if
-#' break labels are provided.
+#' numeric but for some functions, including \code{draw_ordered} and
+#' \code{draw_categorical}, may be factor if labels are provided.
 #' @name draw_discrete
 #' @examples
 #'
@@ -232,7 +232,7 @@ draw_categorical <- function(prob = link(latent), N = NULL,
   draws <- apply(prob, 1, rcateg)
 
   if(!is.null(category_labels)) {
-    return(category_labels[draws])
+    return(factor(draws, levels = 1:m, labels = category_labels))
   } else {
     return(draws)
   }
@@ -294,8 +294,10 @@ draw_ordered <- function(x = link(latent),
 
   if (!is.null(break_labels)) {
     ret <- factor(
-      break_labels[findInterval(x, breaks) + add_to_value],
-      levels = break_labels
+      findInterval(x, breaks) + add_to_value,
+      levels = 1:length(break_labels),
+      labels = break_labels,
+      ordered = TRUE
     )
   } else {
     ret <- findInterval(x, breaks) + add_to_value

--- a/man/draw_discrete.Rd
+++ b/man/draw_discrete.Rd
@@ -101,8 +101,8 @@ for deciles, 10.}
 }
 \value{
 A vector of data in accordance with the specification; generally
-numeric but for some functions, including \code{draw_ordered}, may be factor if
-break labels are provided.
+numeric but for some functions, including \code{draw_ordered} and
+\code{draw_categorical}, may be factor if labels are provided.
 }
 \description{
 Drawing discrete data based on probabilities or latent traits is a common

--- a/tests/testthat/test-variables.R
+++ b/tests/testthat/test-variables.R
@@ -205,9 +205,12 @@ test_that("Categorical valid tests", {
   second <- draw_categorical(prob = matrix(
       rep(c(0, 1, 0), 3),
       byrow = TRUE, ncol = 3, nrow = 3
-    ),category_labels = c("A", "B", "C"))
+    ), category_labels = c("A", "B", "C"))
 
-  expect_equal(second, c("B","B","B"))
+  expect_equal(
+    second,
+    factor(c("B", "B", "B"), levels = c("A", "B", "C"))
+  )
   # Convert vector of probabilities to matrix of probabilities
   # Sunset as per #121, leaving deprecated test.
   #expect_message(draw_categorical(prob = c(0.3, 0.3, 0.4), N = 3))
@@ -261,6 +264,16 @@ test_that("Ordered data valid tests", {
   )
   expect_equal(length(base_ordered), 200)
   expect_equal(length(table(base_ordered)), 4)
+
+  second <- draw_ordered(
+    x = rep(-0.5, 3),
+    breaks = c(-1, 0, 1),
+    break_labels = c("A", "B", "C", "D")
+  )
+  expect_equal(
+    second,
+    factor(c("B", "B", "B"), levels = c("A", "B", "C", "D"), ordered = TRUE)
+  )
 })
 
 


### PR DESCRIPTION
Fixes #186 

* **Breaking change:** `draw_categorical()` returns factor when `category_labels` is specified
* **Breaking change:** `draw_ordered()` returns ordered factor instead of unordered factor
* `draw_ordered()` no longer generates intermediate character vector